### PR TITLE
reorganized team data access interface to follow CA rules

### DIFF
--- a/src/main/java/app/AppBuilder.java
+++ b/src/main/java/app/AppBuilder.java
@@ -18,7 +18,7 @@ import interface_adapter.team_view.TeamViewModel;
 import interface_adapter.best_team.BestTeamController;
 import interface_adapter.best_team.BestTeamPresenter;
 import interface_adapter.best_team.BestTeamViewModel;
-import use_case.TeamDataAccessInterface;
+import use_case.team_entry.TeamDataAccessInterface;
 import use_case.display_individual_stat.DisplayIndividualStatInputBoundary;
 import use_case.display_individual_stat.DisplayIndividualStatInteractor;
 import use_case.display_individual_stat.DisplayIndividualStatOutputBoundary;

--- a/src/main/java/data_access/FileTeamDataAccessObject.java
+++ b/src/main/java/data_access/FileTeamDataAccessObject.java
@@ -2,7 +2,7 @@ package data_access;
 
 import entity.Player;
 import entity.Team;
-import use_case.TeamDataAccessInterface;
+import use_case.team_entry.TeamDataAccessInterface;
 
 import org.json.JSONArray;
 import org.json.JSONException;

--- a/src/main/java/data_access/InMemoryTeamDataAccess.java
+++ b/src/main/java/data_access/InMemoryTeamDataAccess.java
@@ -1,7 +1,7 @@
 package data_access;
 
 import entity.Team;
-import use_case.TeamDataAccessInterface;
+import use_case.team_entry.TeamDataAccessInterface;
 
 public class InMemoryTeamDataAccess implements TeamDataAccessInterface {
 

--- a/src/main/java/use_case/starting_lineup/StartingLineupInteractor.java
+++ b/src/main/java/use_case/starting_lineup/StartingLineupInteractor.java
@@ -2,7 +2,7 @@ package use_case.starting_lineup;
 
 import entity.Player;
 import entity.Team;
-import use_case.TeamDataAccessInterface;
+import use_case.team_entry.TeamDataAccessInterface;
 
 import java.util.ArrayList;
 import java.util.Comparator;

--- a/src/main/java/use_case/team_entry/TeamDataAccessInterface.java
+++ b/src/main/java/use_case/team_entry/TeamDataAccessInterface.java
@@ -1,4 +1,4 @@
-package use_case;
+package use_case.team_entry;
 
 import entity.Team;
 

--- a/src/main/java/use_case/team_entry/TeamEntryInteractor.java
+++ b/src/main/java/use_case/team_entry/TeamEntryInteractor.java
@@ -3,7 +3,6 @@ package use_case.team_entry;
 import entity.Player;
 import entity.Team;
 import use_case.PlayerDataAccessInterface;
-import use_case.TeamDataAccessInterface;
 
 import java.util.ArrayList;
 import java.util.HashSet;

--- a/src/main/java/use_case/transfer_suggestions/TransferSuggestionsInteractor.java
+++ b/src/main/java/use_case/transfer_suggestions/TransferSuggestionsInteractor.java
@@ -3,7 +3,7 @@ package use_case.transfer_suggestions;
 import entity.Player;
 import entity.Team;
 import use_case.PlayerDataAccessInterface;
-import use_case.TeamDataAccessInterface;
+import use_case.team_entry.TeamDataAccessInterface;
 
 import java.util.*;
 

--- a/src/main/java/view/TeamEntryView.java
+++ b/src/main/java/view/TeamEntryView.java
@@ -18,6 +18,7 @@ import java.beans.PropertyChangeListener;
 
 /**
  * The View for the Team Entry Page of the Premier League Fantasy App
+ * NOTES - add presetner + view model for test scrollable list view v2 in constructor, extend property change listener, replace current panel with code that displays panel in test scrollable list view v2
  */
 public class TeamEntryView extends JPanel implements PropertyChangeListener {
 

--- a/src/test/java/use_Case/starting_lineup/StartingLineupInteractorTest.java
+++ b/src/test/java/use_Case/starting_lineup/StartingLineupInteractorTest.java
@@ -4,7 +4,7 @@ import entity.Player;
 import entity.Team;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import use_case.TeamDataAccessInterface;
+import use_case.team_entry.TeamDataAccessInterface;
 
 import java.util.ArrayList;
 import java.util.HashMap;


### PR DESCRIPTION
For use cases that use the user's entered team, please get the data from the data persistence team.json file instead of accessing this interface directly.